### PR TITLE
Fix for #371 ReadChannel#requestMetaData leaks

### DIFF
--- a/mq/main/mq-client/src/main/java/com/sun/messaging/jmq/jmsclient/ReadChannel.java
+++ b/mq/main/mq-client/src/main/java/com/sun/messaging/jmq/jmsclient/ReadChannel.java
@@ -1193,6 +1193,7 @@ public class ReadChannel implements PacketDispatcher, Runnable {
         }
         long ackId = pkt.getConsumerID();
         AsyncSendCallback cb = (AsyncSendCallback)requestMetaData.get(Long.valueOf(ackId));
+        requestMetaData.remove(ackId); 
         if (cb == null) {
             return false;
         }     


### PR DESCRIPTION
This is a fix for Issue #371 (ReadChannel#requestMetaData leaks)

`requestMetaData` is a `Map` of pending requests to the server. The issue is that when the ack is received and processed by `asyncSendAcknowledge(ReadWritePacket pkt)` , the ack is not removed from the map. My proposed change fixes this. 

There are two other methods in `ReadChannel` which are used to process acks (all three places are called from `dispatch()`) , and these do remove the ack from the map.

Note that if the ack is not found this method does nothing.

I have tested this manually (with async send), using print statements to confirm that the map is cleaned up.